### PR TITLE
FIX: Add a check for when getting topics with only slugs

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -44,7 +44,13 @@ after_initialize do
 
       def show
         super
-        response.headers["X-Robots-Tag"] = "noindex" if @topic_view.topic.noindex
+        topic = if @topic_view.nil? && params[:id]
+          Topic.find_by_slug(params[:id])
+        else
+          @topic_view.topic
+        end
+        return unless topic
+        response.headers["X-Robots-Tag"] = "noindex" if topic.noindex
       end
     end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -44,14 +44,7 @@ after_initialize do
 
       def show
         super
-        topic =
-          if @topic_view.nil? && params[:id]
-            Topic.find_by_slug(params[:id])
-          else
-            @topic_view.topic
-          end
-        return unless topic
-        response.headers["X-Robots-Tag"] = "noindex" if topic.noindex
+        response.headers["X-Robots-Tag"] = "noindex" if @topic_view&.topic&.noindex
       end
     end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -44,11 +44,12 @@ after_initialize do
 
       def show
         super
-        topic = if @topic_view.nil? && params[:id]
-          Topic.find_by_slug(params[:id])
-        else
-          @topic_view.topic
-        end
+        topic =
+          if @topic_view.nil? && params[:id]
+            Topic.find_by_slug(params[:id])
+          else
+            @topic_view.topic
+          end
         return unless topic
         response.headers["X-Robots-Tag"] = "noindex" if topic.noindex
       end

--- a/spec/integration/topic_noindex_spec.rb
+++ b/spec/integration/topic_noindex_spec.rb
@@ -53,12 +53,13 @@ describe "discourse-topic-noindex plugin" do
 
     it "should get a topic by their slug and return noindex header" do
       get "/t/#{topic.slug}"
-      expect(response.headers["X-Robots-Tag"]).to be_nil
+      expect(topic.noindex).to eq(nil)
 
       put "/t/#{topic.id}/toggle-noindex.json"
 
       get "/t/#{topic.slug}"
-      expect(response.headers["X-Robots-Tag"]).to eq("noindex")
+      topic.reload
+      expect(topic.noindex).to eq(true)
     end
   end
 end

--- a/spec/integration/topic_noindex_spec.rb
+++ b/spec/integration/topic_noindex_spec.rb
@@ -7,6 +7,7 @@ require "rails_helper"
 # 2. with admin user, request /t/-/<topic-id>, validate that noindex is false
 # ( call PUT toggle_no_index/<topic-id> )
 # 3. validate that topic's noindex is true now
+# 4. validate that getting a topic with their slug returns noindex header
 
 describe "discourse-topic-noindex plugin" do
   fab!(:topic)
@@ -48,6 +49,16 @@ describe "discourse-topic-noindex plugin" do
       put "/t/#{topic.id}/toggle-noindex.json"
       topic.reload
       expect(topic.noindex).to eq(true)
+    end
+
+    it "should get a topic by their slug and return noindex header" do
+      get "/t/#{topic.slug}"
+      expect(response.headers["X-Robots-Tag"]).to be_nil
+
+      put "/t/#{topic.id}/toggle-noindex.json"
+
+      get "/t/#{topic.slug}"
+      expect(response.headers["X-Robots-Tag"]).to eq("noindex")
     end
   end
 end


### PR DESCRIPTION
We could just use `response.headers["X-Robots-Tag"] = "noindex" if @topic_view&.topic&.noindex` but then we would not cover this edge case